### PR TITLE
ci: use gh-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: [self-hosted, light]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [16]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: [self-hosted, light]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description
CI runtimes seem to be way better on GH infra, so using that.